### PR TITLE
Fix author validation

### DIFF
--- a/pyked/tests/test_validation.py
+++ b/pyked/tests/test_validation.py
@@ -53,6 +53,7 @@ class TestCompareName(object):
         ('First Middle Second', 'Last', 'F. M. S. Last'),
         ('F. M. S.', 'Lastone Lasttwo', 'F. M. S. Lastone Lasttwo'),
         ('First Middle Second', 'Lastone Lasttwo', 'First Middle Second Lastone Lasttwo'),
+        ('F. M. S.', 'Lastone-Lasttwo', 'F. M. S. Lastone-Lasttwo'),
     ])
     def test_matching_names(self, given, family, question_name):
         """ Ensure that all tested names compare correctly.

--- a/pyked/tests/test_validation.py
+++ b/pyked/tests/test_validation.py
@@ -18,90 +18,46 @@ v = OurValidator(schema)
 class TestCompareName(object):
     """
     """
-    def test_matching_name(self):
-        """ Kyle Niemeyer vs Kyle Niemeyer
+    @pytest.mark.parametrize('given, family, question_name', [
+        ('Kyle', 'Niemeyer', 'Kyle Niemeyer'),
+        ('Kyle', 'Niemeyer', 'K Niemeyer'),
+        ('K', 'Niemeyer', 'Kyle Niemeyer'),
+        ('Kyle', 'Niemeyer', 'Kyle E. Niemeyer'),
+        ('K', 'Niemeyer', 'Kyle E. Niemeyer'),
+        ('Kyle', 'Niemeyer', 'K. E. Niemeyer'),
+        ('K', 'Niemeyer', 'K. E. Niemeyer'),
+        ('Kyle', 'Niemeyer', 'K E Niemeyer'),
+        ('K', 'Niemeyer', 'K E Niemeyer'),
+        ('Kyle', 'Niemeyer', 'KE Niemeyer'),
+        ('K', 'Niemeyer', 'KE Niemeyer'),
+        ('Chih-Jen', 'Sung', 'Chih-Jen Sung'),
+        ('Chih-Jen', 'Sung', 'C Sung'),
+        ('C', 'Sung', 'Chih-Jen Sung'),
+        ('Chih-Jen', 'Sung', 'C.-J. Sung'),
+        ('Chih-Jen', 'Sung', 'C J Sung'),
+        ('Chih-Jen', 'Sung', 'C-J Sung'),
+        ('C J', 'Sung', 'Chih-Jen Sung'),
+        ('C-J', 'Sung', 'Chih-Jen Sung'),
+        ('Chih-Jen', 'Sung', 'CJ Sung'),
+        ('CJ', 'Sung', 'Chih-Jen Sung'),
+        ('Kyle', 'Niemeyer', 'Niemeyer, Kyle E'),
+        ('Kyle', 'Niemeyer', 'Niemeyer, Kyle E.'),
+        ('Chih-Jen', 'Sung', 'Sung, Chih-Jen'),
+        ('Chih-Jen', 'Sung', 'Sung, C-J'),
+        ('Chih-Jen', 'Sung', 'Sung, C.-J.'),
+        ('Chih-Jen', 'Sung', 'Sung, C J'),
+        ('Chih-Jen', 'Sung', 'Sung, C. J.'),
+        ('Chih-Jen', 'Sung', 'Sung, CJ'),
+        ('F. M. S.', 'Last', 'F. M. S. Last'),
+        ('F. M. S.', 'Last', 'First Middle Second Last'),
+        ('First Middle Second', 'Last', 'F. M. S. Last'),
+        ('F. M. S.', 'Lastone Lasttwo', 'F. M. S. Lastone Lasttwo'),
+        ('First Middle Second', 'Lastone Lasttwo', 'First Middle Second Lastone Lasttwo'),
+    ])
+    def test_matching_names(self, given, family, question_name):
+        """ Ensure that all tested names compare correctly.
         """
-        assert compare_name('Kyle', 'Niemeyer', 'Kyle Niemeyer')
-
-    def test_matching_first_initial(self):
-        """ Kyle Niemeyer vs K Niemeyer
-        """
-        assert compare_name('Kyle', 'Niemeyer', 'K Niemeyer')
-        assert compare_name('K', 'Niemeyer', 'Kyle Niemeyer')
-
-    def test_matching_full_name(self):
-        """ Kyle Niemeyer vs Kyle E. Niemeyer
-        """
-        assert compare_name('Kyle', 'Niemeyer', 'Kyle E. Niemeyer')
-        assert compare_name('K', 'Niemeyer', 'Kyle E. Niemeyer')
-
-    def test_matching_initials_periods(self):
-        """ Kyle Niemeyer vs K. E. Niemeyer
-        """
-        assert compare_name('Kyle', 'Niemeyer', 'K. E. Niemeyer')
-        assert compare_name('K', 'Niemeyer', 'K. E. Niemeyer')
-
-    def test_matching_initials(self):
-        """ Kyle Niemeyer vs K E Niemeyer
-        """
-        assert compare_name('Kyle', 'Niemeyer', 'K E Niemeyer')
-        assert compare_name('K', 'Niemeyer', 'K E Niemeyer')
-
-    def test_matching_initials_combined(self):
-        """ Kyle Niemeyer vs KE Niemeyer
-        """
-        assert compare_name('Kyle', 'Niemeyer', 'KE Niemeyer')
-        assert compare_name('K', 'Niemeyer', 'KE Niemeyer')
-
-    def test_matching_name_hyphen(self):
-        """ Chih-Jen Sung vs Chih-Jen Sung
-        """
-        assert compare_name('Chih-Jen', 'Sung', 'Chih-Jen Sung')
-
-    def test_matching_first_initial_hyphen(self):
-        """ Chih-Jen Sung vs C Sung
-        """
-        assert compare_name('Chih-Jen', 'Sung', 'C Sung')
-        assert compare_name('C', 'Sung', 'Chih-Jen Sung')
-
-    def test_matching_initials_periods_hyphen(self):
-        """ Chih-Jen Sung vs C.-J. Sung
-        """
-        assert compare_name('Chih-Jen', 'Sung', 'C.-J. Sung')
-
-    def test_matching_initials_hyphens(self):
-        """ Chih-Jen Sung vs C J Sung
-        """
-        assert compare_name('Chih-Jen', 'Sung', 'C J Sung')
-        assert compare_name('Chih-Jen', 'Sung', 'C-J Sung')
-        assert compare_name('C J', 'Sung', 'Chih-Jen Sung')
-        assert compare_name('C-J', 'Sung', 'Chih-Jen Sung')
-
-    def test_matching_initials_combined_hyphen(self):
-        """ Chih-Jen Sung vs CJ Sung
-        """
-        assert compare_name('Chih-Jen', 'Sung', 'CJ Sung')
-        assert compare_name('CJ', 'Sung', 'Chih-Jen Sung')
-
-    def test_matching_name_comma(self):
-        """ Kyle Niemeyer vs Niemeyer, Kyle E
-        """
-        assert compare_name('Kyle', 'Niemeyer', 'Niemeyer, Kyle E')
-        assert compare_name('Kyle', 'Niemeyer', 'Niemeyer, Kyle E.')
-
-    def test_matching_name_comma_hyphen(self):
-        """ Chih-Jen Sung vs Sung, Chih-Jen
-        """
-        assert compare_name('Chih-Jen', 'Sung', 'Sung, Chih-Jen')
-
-    def test_matching_name_comma_hyphen_initials(self):
-        """ Chih-Jen Sung vs Sung, C-J
-        """
-        assert compare_name('Chih-Jen', 'Sung', 'Sung, C-J')
-        assert compare_name('Chih-Jen', 'Sung', 'Sung, C.-J.')
-        assert compare_name('Chih-Jen', 'Sung', 'Sung, C J')
-        assert compare_name('Chih-Jen', 'Sung', 'Sung, C. J.')
-        assert compare_name('Chih-Jen', 'Sung', 'Sung, CJ')
+        assert compare_name(given, family, question_name)
 
 
 class TestValidator(object):

--- a/pyked/validation.py
+++ b/pyked/validation.py
@@ -85,22 +85,30 @@ def compare_name(given_name, family_name, question_name):
         name_split.reverse()
         question_name = ' '.join(name_split).strip()
 
+    # remove periods
+    question_name = question_name.replace('.', '')
+    given_name = given_name.replace('.', '')
+    family_name = family_name.replace('.', '')
+
+    # split names by , <space> - .
+    given_name = list(filter(None, re.split("[, \-.]+", given_name)))
+    num_family_names = len(list(filter(None, re.split("[, \-.]+", family_name))))
+
     # split name in question by , <space> - .
     name_split = list(filter(None, re.split("[, \-.]+", question_name)))
     first_name = [name_split[0]]
-    if len(name_split) == 3:
-        first_name += [name_split[1]]
+    if len(name_split) > 2:
+        first_name += [n for n in name_split[1 : -num_family_names]]
 
-    given_name = list(filter(None, re.split("[, \-.]+", given_name)))
-
-    if len(first_name) == 2 and len(given_name) == 2:
-        # both have first and middle name/initial
-        first_name[1] = first_name[1][0]
-        given_name[1] = given_name[1][0]
-    elif len(given_name) == 2 and len(first_name) == 1:
-        del given_name[1]
-    elif len(first_name) == 2 and len(given_name) == 1:
-        del first_name[1]
+    if len(first_name) > 1 and len(given_name) == len(first_name):
+        # both have same number of first and middle names/initials
+        for i in range(1, len(first_name)):
+            first_name[i] = first_name[i][0]
+            given_name[i] = given_name[i][0]
+    elif len(given_name) != len(first_name):
+        min_names = min(len(given_name), len(first_name))
+        first_name = first_name[:min_names]
+        given_name = given_name[:min_names]
 
     # first initial
     if len(first_name[0]) == 1 or len(given_name[0]) == 1:
@@ -108,11 +116,11 @@ def compare_name(given_name, family_name, question_name):
         first_name[0] = first_name[0][0]
 
     # first and middle initials combined
-    if len(first_name[0]) == 2 or len(given_name[0]) == 2:
+    if len(first_name[0]) > 1 or len(given_name[0]) > 1:
         given_name[0] = given_name[0][0]
         first_name[0] = name_split[0][0]
 
-    return given_name == first_name and family_name == name_split[-1]
+    return given_name == first_name and family_name == ' '.join(name_split[-num_family_names:])
 
 
 class OurValidator(Validator):

--- a/pyked/validation.py
+++ b/pyked/validation.py
@@ -92,7 +92,7 @@ def compare_name(given_name, family_name, question_name):
 
     # split names by , <space> - .
     given_name = list(filter(None, re.split("[, \-.]+", given_name)))
-    num_family_names = len(list(filter(None, re.split("[, \-.]+", family_name))))
+    num_family_names = len(list(filter(None, re.split("[, .]+", family_name))))
 
     # split name in question by , <space> - .
     name_split = list(filter(None, re.split("[, \-.]+", question_name)))
@@ -120,7 +120,14 @@ def compare_name(given_name, family_name, question_name):
         given_name[0] = given_name[0][0]
         first_name[0] = name_split[0][0]
 
-    return given_name == first_name and family_name == ' '.join(name_split[-num_family_names:])
+    # Hyphenated last name may need to be reconnected
+    if num_family_names == 1 and '-' in family_name:
+        num_hyphen = family_name.count('-')
+        family_name_compare = '-'.join(name_split[-(num_hyphen + 1):])
+    else:
+        family_name_compare = ' '.join(name_split[-num_family_names:])
+
+    return given_name == first_name and family_name == family_name_compare
 
 
 class OurValidator(Validator):


### PR DESCRIPTION
- [x] Fixes #37 and #40.
- [x] Tests added: `test_matching_names`

Changes proposed in this pull request:
 - Make author validation more robust to handle given names with more than two names (i.e., more than just one first and one middle), and also to handle double-barrel and hyphenated family names.
 - `test_matching_names` now uses pytest fixture to go through a list of test inputs, rather than using many separate tests

@pr-omethe-us/chemked
