### PR TITLE
Add skip validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,10 @@ language: generic
 matrix:
   include:
     - os: linux
-      env: PYTHON="2.7"
-
-    - os: linux
       env: PYTHON="3.5"
 
     - os: linux
       env: PYTHON="3.6"
-
-    - os: osx
-      env: PYTHON="2.7"
 
     - os: osx
       env: PYTHON="3.5"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Add `skip_validation` keyword argument to the `ChemKED` initializer
 
 ### Fixed
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,6 @@ environment:
     secure: agG4yvYjpYq1nzjLhnZ92Z6ZFVM+KA5JyYIYwX2YVQxpuRj7myqJNfttUVTqynIg
 
   matrix:
-    - PYTHON_LOC: "C:\\Miniconda-x64"
-      PYTHON_VERSION: "2.7"
-
     - PYTHON_LOC: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.5"
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   build:
-    - python >=2.7,<3|>=3.5,{{PY_VER}}*
+    - python >=3.5,{{PY_VER}}*
     - setuptools
 
   run:

--- a/pyked/chemked.py
+++ b/pyked/chemked.py
@@ -45,6 +45,8 @@ class ChemKED(object):
         yaml_file (`str`, optional): The filename of the YAML database in ChemKED format.
         dict_input (`str`, optional): A dictionary with the parsed ouput of YAML file in ChemKED
             format.
+        skip_validation (`bool`, optional): Whether validation of the ChemKED should be done. Must
+            be supplied as a keyword-argument.
 
     Attributes:
         datapoints (`list`): List of `DataPoint` objects storing each datapoint in the database.
@@ -59,7 +61,7 @@ class ChemKED(object):
         file_author (`dict`): Information about the author of the ChemKED database file.
         file_version (`str`): Version of the ChemKED database file.
     """
-    def __init__(self, yaml_file=None, dict_input=None):
+    def __init__(self, yaml_file=None, dict_input=None, *, skip_validation=False):
         if yaml_file is not None:
             with open(yaml_file, 'r') as f:
                 properties = yaml.safe_load(f)
@@ -68,7 +70,8 @@ class ChemKED(object):
         else:
             raise NameError("ChemKED needs either a YAML filename or dictionary as input.")
 
-        self.validate_yaml(properties)
+        if not skip_validation:
+            self.validate_yaml(properties)
 
         self.datapoints = []
         for point in properties['datapoints']:

--- a/pyked/chemked.py
+++ b/pyked/chemked.py
@@ -1,11 +1,9 @@
 """
 Main ChemKED module
 """
-from __future__ import print_function, division
 from collections import namedtuple
 from warnings import warn
 from copy import deepcopy
-from sys import version_info
 
 import numpy as np
 
@@ -14,29 +12,26 @@ from .validation import schema, OurValidator, yaml
 from .utils import Q_
 
 VolumeHistory = namedtuple('VolumeHistory', ['time', 'volume'])
-if version_info.major >= 3:
-    VolumeHistory.__doc__ = 'Time history of the volume in an RCM experiment'
-    VolumeHistory.time.__doc__ = '(`~numpy.ndarray`): the time during the experiment'
-    VolumeHistory.volume.__doc__ = '(`~numpy.ndarray`): the volume during the experiment'
+VolumeHistory.__doc__ = 'Time history of the volume in an RCM experiment'
+VolumeHistory.time.__doc__ = '(`~numpy.ndarray`): the time during the experiment'
+VolumeHistory.volume.__doc__ = '(`~numpy.ndarray`): the volume during the experiment'
 
 Reference = namedtuple('Reference',
                        ['volume', 'journal', 'doi', 'authors', 'detail', 'year', 'pages'])
-if version_info.major >= 3:
-    Reference.__doc__ = 'Information about the article or report where the data can be found'
-    Reference.volume.__doc__ = '(`str`) The journal volume'
-    Reference.journal.__doc__ = '(`str`) The name of the journal'
-    Reference.doi.__doc__ = '(`str`) The Digital Object Identifier of the article'
-    Reference.authors.__doc__ = '(`list`) The list of authors of the article'
-    Reference.detail.__doc__ = '(`str`) Detail about where the data can be found in the article'
-    Reference.year.__doc__ = '(`str`) The year the article was published'
-    Reference.pages.__doc__ = '(`str`) The pages in the journal where the article was published'
+Reference.__doc__ = 'Information about the article or report where the data can be found'
+Reference.volume.__doc__ = '(`str`) The journal volume'
+Reference.journal.__doc__ = '(`str`) The name of the journal'
+Reference.doi.__doc__ = '(`str`) The Digital Object Identifier of the article'
+Reference.authors.__doc__ = '(`list`) The list of authors of the article'
+Reference.detail.__doc__ = '(`str`) Detail about where the data can be found in the article'
+Reference.year.__doc__ = '(`str`) The year the article was published'
+Reference.pages.__doc__ = '(`str`) The pages in the journal where the article was published'
 
 Apparatus = namedtuple('Apparatus', ['kind', 'institution', 'facility'])
-if version_info.major >= 3:
-    Apparatus.__doc__ = 'Information about the experimental apparatus used to generate the data'
-    Apparatus.kind.__doc__ = '(`str`) The kind of experimental apparatus'
-    Apparatus.institution.__doc__ = '(`str`) The institution where the experiment is located'
-    Apparatus.facility.__doc__ = '(`str`) The particular experimental facility at the location'
+Apparatus.__doc__ = 'Information about the experimental apparatus used to generate the data'
+Apparatus.kind.__doc__ = '(`str`) The kind of experimental apparatus'
+Apparatus.institution.__doc__ = '(`str`) The institution where the experiment is located'
+Apparatus.facility.__doc__ = '(`str`) The particular experimental facility at the location'
 
 
 class ChemKED(object):

--- a/pyked/tests/test_chemked.py
+++ b/pyked/tests/test_chemked.py
@@ -4,6 +4,7 @@ Test module for chemked.py
 # Standard libraries
 import os
 import pkg_resources
+import warnings
 
 # Third-party libraries
 import numpy as np
@@ -13,6 +14,8 @@ import pytest
 from ..validation import schema, OurValidator, yaml
 from ..chemked import ChemKED, DataPoint
 from ..utils import Q_
+
+warnings.simplefilter('always')
 
 
 class TestChemKED(object):

--- a/pyked/tests/test_chemked.py
+++ b/pyked/tests/test_chemked.py
@@ -4,7 +4,6 @@ Test module for chemked.py
 # Standard libraries
 import os
 import pkg_resources
-import warnings
 
 # Third-party libraries
 import numpy as np
@@ -15,7 +14,6 @@ from ..validation import schema, OurValidator, yaml
 from ..chemked import ChemKED, DataPoint
 from ..utils import Q_
 
-warnings.simplefilter("always")
 
 class TestChemKED(object):
     """

--- a/pyked/tests/test_chemked.py
+++ b/pyked/tests/test_chemked.py
@@ -26,6 +26,11 @@ class TestChemKED(object):
         filename = pkg_resources.resource_filename(__name__, file_path)
         ChemKED(filename)
 
+    def test_skip_validation(self):
+        file_path = os.path.join('testfile_bad.yaml')
+        filename = pkg_resources.resource_filename(__name__, file_path)
+        ChemKED(filename, skip_validation=True)
+
     def test_datapoints(self):
         file_path = os.path.join('testfile_st.yaml')
         filename = pkg_resources.resource_filename(__name__, file_path)


### PR DESCRIPTION
- [x] Tests added
- [x] Added entry into `CHANGELOG.md`

Changes proposed in this pull request:
 - Add keyword to totally skip the validation step when loading a ChemKED file
 - Revert support for Python 2.7 because the keyword-only argument for the initializer is supported by Python 3.0+

In the future, we might want to consider disabling parts of the validation, but as a global solution, this works pretty well :smiley:

@pr-omethe-us/chemked
