### PR TITLE
fixed Cantera convenience function outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Fixed
+- Fixes Cantera convenience output functions
 
 ### Changed
 

--- a/pyked/chemked.py
+++ b/pyked/chemked.py
@@ -647,11 +647,11 @@ class DataPoint(object):
             `str`: String in the ``SPEC: AMT, SPEC: AMT`` format
         """
         if self.composition_type == 'mole fraction':
-            return ', '.join(['{!s}: {:.4e}'.format(c['species-name'],
+            return ', '.join(['{!s}:{:.4e}'.format(c['species-name'],
                              c['amount'].magnitude) for c in self.composition]
                              )
         elif self.composition_type == 'mole percent':
-            return ', '.join(['{!s}: {:.4e}'.format(c['species-name'],
+            return ', '.join(['{!s}:{:.4e}'.format(c['species-name'],
                              c['amount'].magnitude/100.0) for c in self.composition]
                              )
         else:
@@ -665,7 +665,7 @@ class DataPoint(object):
             `str`: String in the ``SPEC: AMT, SPEC: AMT`` format
         """
         if self.composition_type == 'mass fraction':
-            return ', '.join(['{!s}: {:.4e}'.format(c['species-name'],
+            return ', '.join(['{!s}:{:.4e}'.format(c['species-name'],
                              c['amount'].magnitude) for c in self.composition]
                              )
         else:

--- a/pyked/tests/test_chemked.py
+++ b/pyked/tests/test_chemked.py
@@ -443,7 +443,7 @@ class TestDataPoint(object):
     def test_cantera_composition_mole_fraction(self):
         properties = self.load_properties('testfile_required.yaml')
         d = DataPoint(properties[0])
-        assert d.get_cantera_mole_fraction() == 'H2: 4.4400e-03, O2: 5.5600e-03, Ar: 9.9000e-01'
+        assert d.get_cantera_mole_fraction() == 'H2:4.4400e-03, O2:5.5600e-03, Ar:9.9000e-01'
 
     def test_cantera_composition_mole_fraction_bad(self):
         properties = self.load_properties('testfile_required.yaml')
@@ -454,7 +454,7 @@ class TestDataPoint(object):
     def test_cantera_composition_mass_fraction(self):
         properties = self.load_properties('testfile_required.yaml')
         d = DataPoint(properties[1])
-        assert d.get_cantera_mass_fraction() == 'H2: 2.2525e-04, O2: 4.4775e-03, Ar: 9.9530e-01'
+        assert d.get_cantera_mass_fraction() == 'H2:2.2525e-04, O2:4.4775e-03, Ar:9.9530e-01'
 
     def test_cantera_composition_mass_fraction_bad(self):
         properties = self.load_properties('testfile_required.yaml')
@@ -465,7 +465,7 @@ class TestDataPoint(object):
     def test_cantera_composition_mole_percent(self):
         properties = self.load_properties('testfile_required.yaml')
         d = DataPoint(properties[2])
-        assert d.get_cantera_mole_fraction() == 'H2: 4.4400e-03, O2: 5.5600e-03, Ar: 9.9000e-01'
+        assert d.get_cantera_mole_fraction() == 'H2:4.4400e-03, O2:5.5600e-03, Ar:9.9000e-01'
 
     def test_composition(self):
         properties = self.load_properties('testfile_required.yaml')


### PR DESCRIPTION
- [x] Fixes #72 
- [x] Tests updated
- [x] Added entry into `CHANGELOG.md`

Changes proposed in this pull request:
 - Fixes output of Cantera convenience mole/mass fraction functions to match what Cantera actually can read

@pr-omethe-us/chemked
