### PR TITLE
Add noarch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,12 @@ install:
     - export PATH="$HOME/miniconda/bin:$PATH"
     - hash -r
     - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
+    - conda update -q --all
     - conda config --append channels conda-forge
     - if [[ -z "$TRAVIS_TAG" ]]; then
         sed -i -e "s/\${PYTHON}/"${PYTHON}"/" test-environment.yaml;
         conda env create -qf test-environment.yaml;
-        source activate test-environment;
+        source activate py${PYTHON};
       else
         conda install -q conda-build anaconda-client;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,10 @@ script:
         doctr deploy .;
       fi
     else
-      conda build conda.recipe --python=${PYTHON};
-      anaconda -t $ANACONDA_TOKEN upload $HOME/miniconda/conda-bld/*/pyked*.tar.bz2;
+      if [[ "$PYTHON" == "3.6" && "$TRAVIS_OS_NAME" == "linux" ]]; then
+        conda build conda.recipe;
+        anaconda -t $ANACONDA_TOKEN upload $HOME/miniconda/conda-bld/*/pyked*.tar.bz2;
+      fi
     fi
   - set +e
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 ### Changed
+- Conda builds are now noarch - one package for all Pythons!
+- pip installs now require Python compatible with 3.5
+- Appveyor runs a single job and no longer builds conda packages
 
 ## [0.2.1] - 2017-08-31
 ### Fixed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,30 +1,26 @@
 version: 1.0.{build}
 environment:
-  ANACONDA_KEY:
-    secure: agG4yvYjpYq1nzjLhnZ92Z6ZFVM+KA5JyYIYwX2YVQxpuRj7myqJNfttUVTqynIg
+  PYTHON_LOC: "C:\\Miniconda36-x64"
 
-  matrix:
-    - PYTHON_LOC: "C:\\Miniconda36-x64"
-      PYTHON_VERSION: "3.5"
-
-    - PYTHON_LOC: "C:\\Miniconda36-x64"
-      PYTHON_VERSION: "3.6"
+skip_tags: true
 
 install:
   - cmd: call %PYTHON_LOC%\Scripts\activate.bat
   - cmd: conda config --set always_yes yes --set changeps1 no
   - cmd: conda config --append channels conda-forge
-  - cmd: conda update -q conda
-  - ps: (get-content test-environment.yaml) | %{$_ -replace "\$\{PYTHON\}",$env:PYTHON_VERSION} | set-content test-environment.yaml
-  - cmd: IF "%APPVEYOR_REPO_TAG%"=="false" conda env create -qf test-environment.yaml
-  - cmd: IF "%APPVEYOR_REPO_TAG%"=="false" call %PYTHON_LOC%\Scripts\activate.bat test-environment
-  - cmd: IF "%APPVEYOR_REPO_TAG%"=="true" conda install -yq anaconda-client conda-build
+  - cmd: conda update -q --all
+  - ps: (get-content test-environment.yaml) | %{$_ -replace "\$\{PYTHON\}","3.5"} | set-content test-environment.yaml
+  - cmd: conda env create -qf test-environment.yaml
+  - cmd: git checkout -- test-environment.yaml
+  - ps: (get-content test-environment.yaml) | %{$_ -replace "\$\{PYTHON\}","3.6"} | set-content test-environment.yaml
+  - cmd: conda env create -qf test-environment.yaml
   - cmd: conda info -a
   - cmd: conda list
 
 build_script:
-  - cmd: IF "%APPVEYOR_REPO_TAG%"=="false" python setup.py test
-  - cmd: IF "%APPVEYOR_REPO_TAG%"=="true" conda build conda.recipe --python=%PYTHON_VERSION%
-
-deploy_script:
-  - cmd: IF "%APPVEYOR_REPO_TAG%"=="true" anaconda -t %ANACONDA_KEY% upload "%PYTHON_LOC%\conda-bld\win-64\pyked*.tar.bz2"
+  - cmd: call %PYTHON_LOC%\Scripts\activate.bat py3.5
+  - cmd: python setup.py test
+  - cmd: rmdir /s /q pyked.egg-info
+  - cmd: rmdir /s /q .eggs
+  - cmd: call %PYTHON_LOC%\Scripts\activate.bat py3.6
+  - cmd: python setup.py test

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,18 +10,19 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
+  noarch: python
 
 requirements:
   build:
-    - python >=3.5,{{PY_VER}}*
+    - python >=3.5
     - setuptools
 
   run:
-    - python {{PY_VER}}*
+    - python
     - pyyaml >=3.12,<4.0
-    - cerberus >=1.0.0
-    - pint >=0.7.2
-    - numpy >=1.11.0
+    - cerberus >=1.0.0,<1.2
+    - pint >=0.7.2,<0.9
+    - numpy >=1.11.0,<2.0
     - habanero >=0.2.6
     - orcid >=0.7.0,<1.0
     - uncertainties >=3.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,3 @@ test=pytest
 
 [tool:pytest]
 addopts = -vv --cov=./
-
-[bdist_wheel]
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
     tests_require=tests_require,
     extras_require=extras_require,
     setup_requires=setup_requires,
+    python_requires='~=3.5',
     entry_points = {
         'console_scripts': ['convert_ck=pyked.converters:main',
                             'respth2ck=pyked.converters:respth2ck',

--- a/test-environment.yaml
+++ b/test-environment.yaml
@@ -1,4 +1,4 @@
-name: test-environment
+name: py${PYTHON}
 channels:
 - defaults
 - conda-forge


### PR DESCRIPTION
- [x] Added entry into `CHANGELOG.md`

Changes proposed in this pull request:
 - Switch the conda package to a noarch package, meaning it runs on any version of Python that we indicate is compatible in the recipe (i.e., >=3.5)
 - Require Python compatible with 3.5 for pip installs
 - Remove universal designation for wheels which wasn't appropriate anymore anyways

@pr-omethe-us/chemked
