### PR TITLE
Add extrapolated ignition type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- New extrapolated ignition type, where the maximum slope is extrapolated to the baseline
 
 ### Fixed
 

--- a/pyked/schemas/ignition_delay_schema.yaml
+++ b/pyked/schemas/ignition_delay_schema.yaml
@@ -19,6 +19,7 @@ ignition-type: &ignition-type
         - max
         - 1/2 max
         - min
+        - d/dt max extrapolated
       required: true
       type: string
 

--- a/pyked/tests/test_chemked.py
+++ b/pyked/tests/test_chemked.py
@@ -717,6 +717,16 @@ class TestDataPoint(object):
             assert d.ignition_type['target'] == 'OH*'
             assert d.ignition_type['type'] == '1/2 max'
 
+        # CH, min
+        properties = self.load_properties('testfile_required.yaml')
+        datapoints = [DataPoint(d) for d in properties]
+        assert datapoints[0].ignition_type['target'] == 'CH'
+        assert datapoints[0].ignition_type['type'] == 'min'
+
+        # CH*, d/dt max extrapolted
+        assert datapoints[1].ignition_type['target'] == 'CH*'
+        assert datapoints[1].ignition_type['type'] == 'd/dt max extrapolated'
+
     def test_changing_ignition_type(self):
         properties = self.load_properties('testfile_st.yaml')
         datapoints = [DataPoint(d) for d in properties]

--- a/pyked/tests/test_chemked.py
+++ b/pyked/tests/test_chemked.py
@@ -723,7 +723,7 @@ class TestDataPoint(object):
         assert datapoints[0].ignition_type['target'] == 'CH'
         assert datapoints[0].ignition_type['type'] == 'min'
 
-        # CH*, d/dt max extrapolted
+        # CH*, d/dt max extrapolated
         assert datapoints[1].ignition_type['target'] == 'CH*'
         assert datapoints[1].ignition_type['type'] == 'd/dt max extrapolated'
 

--- a/pyked/tests/test_converters.py
+++ b/pyked/tests/test_converters.py
@@ -144,7 +144,7 @@ class TestGetReference(object):
 
         with pytest.warns(UserWarning) as w:
             ref = get_reference(root)
-        assert w[0].message.args[0] == ('Using DOI to obtain reference information, '
+        assert w[1].message.args[0] == ('Using DOI to obtain reference information, '
                                         'rather than preferredKey.'
                                         )
 
@@ -247,8 +247,10 @@ class TestGetReference(object):
 
         with pytest.warns(UserWarning) as w:
             ref = get_reference(root)
-        assert len(w) == 1
-        assert w[0].message.args[0] == ('Missing doi attribute in bibliographyLink or lookup failed. '
+
+        # This test also raises a ResourceWarning from habanero, so there are 2 warnings stored
+        assert len(w) == 2
+        assert w[1].message.args[0] == ('Missing doi attribute in bibliographyLink or lookup failed. '
                                         'Setting "detail" key as a fallback; please update to '
                                         'the appropriate fields.'
                                         )
@@ -271,8 +273,10 @@ class TestGetReference(object):
 
         with pytest.warns(UserWarning) as w:
             ref = get_reference(root)
-        assert len(w) == 1
-        assert w[0].message.args[0] == ('Missing doi attribute in bibliographyLink or lookup failed. '
+
+        # This test also raises a ResourceWarning from habanero, so there are 2 warnings stored
+        assert len(w) == 2
+        assert w[1].message.args[0] == ('Missing doi attribute in bibliographyLink or lookup failed. '
                                         'Setting "detail" key as a fallback; please update to '
                                         'the appropriate fields.'
                                         )

--- a/pyked/tests/test_validation.py
+++ b/pyked/tests/test_validation.py
@@ -418,6 +418,24 @@ class TestValidator(object):
         # update=True means to ignore required keys that are left out for testing
         assert v.validate({'experiment-type': valid_type}, update=True)
 
+    @pytest.mark.parametrize("valid_type", [
+        'd/dt max', 'max', '1/2 max', 'min', 'd/dt max extrapolated',
+    ])
+    def test_valid_ignition_types(self, valid_type):
+        """Ensure that all the valid experiment types are validated
+        """
+        # update=True means to ignore required keys that are left out for testing
+        assert v.validate({'datapoints': [{'ignition-type': {'type': valid_type}}]}, update=True)
+
+    @pytest.mark.parametrize("valid_target", [
+        'temperature', 'pressure', 'OH', 'OH*', 'CH', 'CH*',
+    ])
+    def test_valid_ignition_targets(self, valid_target):
+        """Ensure that all the valid experiment types are validated
+        """
+        # update=True means to ignore required keys that are left out for testing
+        assert v.validate({'datapoints': [{'ignition-type': {'target': valid_target}}]}, update=True)
+
     @pytest.mark.parametrize("quantity, unit", property_units.items())
     def test_incompatible_quantity(self, quantity, unit):
         """Ensure that incompatible quantities are validation errors

--- a/pyked/tests/testfile_required.yaml
+++ b/pyked/tests/testfile_required.yaml
@@ -34,8 +34,8 @@ datapoints:
           amount:
             - 0.99
     ignition-type:
-      target: pressure
-      type: d/dt max
+      target: CH
+      type: min
   - temperature:
       - 1164.48 kelvin
     ignition-delay:
@@ -58,8 +58,8 @@ datapoints:
           amount:
             - 9.95297294E-1
     ignition-type:
-      target: pressure
-      type: d/dt max
+      target: CH*
+      type: d/dt max extrapolated
   - temperature:
       - 1164.48 kelvin
     ignition-delay:

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@ test=pytest
 
 [tool:pytest]
 addopts = -vv --cov=./
+filterwarnings =
+    ignore::ResourceWarning


### PR DESCRIPTION
- [x] Fixes #71.
- [x] Tests added
- [x] Added entry into `CHANGELOG.md`

Changes proposed in this pull request:
 - Add extrapolated ignition type, where the maximum slope is extrapolated to the baseline

@pr-omethe-us/chemked
