### PR TITLE
removes elemental-composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Tests that the composition type is stored properly in the `DataPoint`
 - `species_conversion` dictionary can be passed to the `get_cantera_mole_fraction` and `get_cantera_mass_fraction` functions to change the name of a species in the output string
 
+### Removed
+- Removes `elemental-composition` as a synonym for `atomic-composition`
+
 ### Fixed
 - Fixes `test_incorrect_doi_period_at_end` docstring
 

--- a/docs/schema-docs.rst
+++ b/docs/schema-docs.rst
@@ -148,25 +148,14 @@ particular experiment type.
         * ``species-name``: string, required
             The name of the species
 
-        * ``InChI``: string, required, excludes ``SMILES``, ``atomic-composition``, ``elemental-composition``
+        * ``InChI``: string, required, excludes ``SMILES``, ``atomic-composition``
             The InChI string for the species
 
-        * ``SMILES``: string, required, excludes ``InChI``, ``atomic-composition``, ``elemental-composition``
+        * ``SMILES``: string, required, excludes ``InChI``, ``atomic-composition``
             The SMILES string for the species
 
-        * ``atomic-composition``: sequence, required, excludes ``InChI``, ``SMILES``, ``elemental-composition``
+        * ``atomic-composition``: sequence, required, excludes ``InChI``, ``SMILES``
             A sequence of mappings representing the atoms that make up the species. Useful for
-            species without SMILES or InChI representations, such as real hydrocarbon fuels. Each
-            element of the sequence is a mapping with the following keys:
-
-            - ``element``: string, required
-                The name of the element
-
-            - ``amount``: float, required, must be greater than 0.0
-                The amount of the element
-
-        * ``elemental-composition``: sequence, required, excludes ``InChI``, ``SMILES``, ``atomic-composition``
-            A sequence of mappings representing the elements that make up the species. Useful for
             species without SMILES or InChI representations, such as real hydrocarbon fuels. Each
             element of the sequence is a mapping with the following keys:
 

--- a/pyked/schemas/composition_schema.yaml
+++ b/pyked/schemas/composition_schema.yaml
@@ -23,14 +23,12 @@ composition: &composition
             excludes:
               - atomic-composition
               - SMILES
-              - elemental-composition
           SMILES:
             type: string
             required: true
             excludes:
               - atomic-composition
               - InChI
-              - elemental-composition
           atomic-composition:
             type: list
             minlength: 1
@@ -38,24 +36,6 @@ composition: &composition
             excludes:
               - InChI
               - SMILES
-              - elemental-composition
-            schema:
-              type: dict
-              schema:
-                element:
-                  type: string
-                amount:
-                  type: float
-                  min: 0.0
-                  # TODO: option for float or int?
-          elemental-composition:
-            type: list
-            minlength: 1
-            required: true
-            excludes:
-              - InChI
-              - SMILES
-              - atomic-composition
             schema:
               type: dict
               schema:

--- a/pyked/validation.py
+++ b/pyked/validation.py
@@ -429,4 +429,4 @@ class OurValidator(Validator):
                         's do not sum to {:.1f}: '.format(total_amount) +
                         '{:f}'.format(sum_amount)
                         )
-        # TODO: validate InChI, SMILES, or elemental-composition/atomic-composition
+        # TODO: validate InChI, SMILES, or atomic-composition


### PR DESCRIPTION
- [x] Added entry into `CHANGELOG.md`

Changes proposed in this pull request:
 - Removes `elemental-composition` as synonym for `atomic-composition`

@pr-omethe-us/chemked
