### PR TITLE
Add classmethod to instantiate ChemKED from ReSpecTh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 ### Added
+- New method to instantiate a `ChemKED` class directly from a ReSpecTh XML file
 
 ### Changed
 - Crossref lookups via Habanero now comply with the "be-nice" policy
 - Removed `UnboundLocalError` from error processing for reference validation
 - Switch to flake8 for style checking in CI services
 - `file-author` field is now a list called `file-authors`
+- ReSpecTh->ChemKED converter function now returns a dictionary, while the command-line entry points write out files
 
 ## [0.3.0] - 2017-10-09
 ### Added

--- a/pyked/chemked.py
+++ b/pyked/chemked.py
@@ -105,6 +105,24 @@ class ChemKED(object):
 
     @classmethod
     def from_respecth(cls, filename_xml, file_author='', file_author_orcid=''):
+        """Construct a ChemKED instance directly from a ReSpecTh file.
+
+        Arguments:
+            filename_xml (`str`): Filename of the ReSpecTh-formatted XML file to be imported
+            file_author (`str`, optional): File author to be added to the list generated from the
+                XML file
+            file_author_orcid (`str`, optional): ORCID for the file author being added to the list
+                of file authors
+
+        Returns:
+            `ChemKED`: Instance of the `ChemKED` class containing the data in ``filename_xml``.
+
+        Examples:
+            >>> ck = ChemKED.from_respecth('respecth_file.xml')
+            >>> ck = ChemKED.from_respecth('respecth_file.xml', file_author='Bryan W. Weber')
+            >>> ck = ChemKED.from_respecth('respecth_file.xml', file_author='Bryan W. Weber',
+                                           file_author_orcid='0000-0000-0000-0000')
+        """
         properties = ReSpecTh_to_ChemKED(filename_xml, file_author, file_author_orcid,
                                          validate=False)
         return cls(dict_input=properties)

--- a/pyked/chemked.py
+++ b/pyked/chemked.py
@@ -14,7 +14,7 @@ import numpy as np
 # Local imports
 from .validation import schema, OurValidator, yaml
 from .utils import Q_
-from .converters import datagroup_properties
+from .converters import datagroup_properties, ReSpecTh_to_ChemKED
 
 VolumeHistory = namedtuple('VolumeHistory', ['time', 'volume'])
 VolumeHistory.__doc__ = 'Time history of the volume in an RCM experiment'
@@ -102,6 +102,12 @@ class ChemKED(object):
 
         for prop in ['chemked-version', 'experiment-type', 'file-authors', 'file-version']:
             setattr(self, prop.replace('-', '_'), self._properties[prop])
+
+    @classmethod
+    def from_respecth(cls, filename_xml, file_author='', file_author_orcid=''):
+        properties = ReSpecTh_to_ChemKED(filename_xml, file_author, file_author_orcid,
+                                         validate=False)
+        return cls(dict_input=properties)
 
     def validate_yaml(self, properties):
         """Validate the parsed YAML file for adherance to the ChemKED format.

--- a/pyked/converters.py
+++ b/pyked/converters.py
@@ -511,11 +511,12 @@ def ReSpecTh_to_ChemKED(filename_xml, filename_ck='', file_author='', file_autho
     if has_vol_hist and properties['apparatus']['kind'] == 'shock tube':
         raise KeywordError('Volume history cannot be defined for shock tube.')
 
-    # apply any overrides
-    if file_author or file_author_orcid:
-        temp_author = {}
-        if file_author:
-            temp_author['name'] = file_author
+    # add any additional file authors
+    if file_author_orcid and not file_author:
+        raise KeywordError('If file_author_orcid is specified, file_author must be as well')
+
+    if file_author:
+        temp_author = {'name': file_author}
         if file_author_orcid:
             temp_author['ORCID'] = file_author_orcid
         properties['file-authors'].append(temp_author)

--- a/pyked/converters.py
+++ b/pyked/converters.py
@@ -104,7 +104,7 @@ def get_reference(root):
     if ref_doi is not None:
         try:
             ref = habanero.Crossref().works(ids=ref_doi)['message']
-        except (HTTPError, habanero.RequestError, ConnectionError, UnboundLocalError):
+        except (HTTPError, habanero.RequestError, ConnectionError):
             if ref_key is None:
                 raise KeywordError('DOI not found and preferredKey attribute not set')
             else:

--- a/pyked/converters.py
+++ b/pyked/converters.py
@@ -462,14 +462,16 @@ def get_datapoints(root):
     return datapoints
 
 
-def ReSpecTh_to_ChemKED(filename_xml, filename_ck='', file_author='', file_author_orcid=''):
-    """Convert ReSpecTh XML file to ChemKED YAML file.
+def ReSpecTh_to_ChemKED(filename_xml, file_author='', file_author_orcid='', *, validate=False):
+    """Convert ReSpecTh XML file to ChemKED-compliant dictionary.
 
     Args:
         filename_xml (`str`): Name of ReSpecTh XML file to be converted.
-        filename_ck (`str`, optional): Name of output ChemKED file to be produced.
         file_author (`str`, optional): Name to override original file author
         file_author_orcid (`str`, optional): ORCID of file author
+        validate (`bool`, optional, keyword-only): Set to `True` to validate the resulting
+            property dictionary with `ChemKED`. Set to `False` if the file is being loaded and will
+            be validated at some other point before use.
     """
     # get all information from XML file
     tree = etree.parse(filename_xml)
@@ -526,22 +528,14 @@ def ReSpecTh_to_ChemKED(filename_xml, filename_ck='', file_author='', file_autho
         for prop in properties['common-properties']:
             properties['datapoints'][idx][prop] = properties['common-properties'][prop]
 
-    # set output filename and path
-    if not filename_ck:
-        filename_ck = os.path.join(os.path.dirname(filename_xml),
-                                   os.path.splitext(os.path.basename(filename_xml))[0] + '.yaml'
-                                   )
+    if validate:
+        chemked.ChemKED(dict_input=properties)
 
-    with open(filename_ck, 'w') as outfile:
-        yaml.dump(properties, outfile, default_flow_style=False)
-    print('Converted to ' + filename_ck)
-
-    # now validate
-    chemked.ChemKED(yaml_file=filename_ck)
+    return properties
 
 
 def respth2ck(argv=None):
-    """Command-line script for converting a ReSpecTh XML file to a ChemKED YAML file.
+    """Command-line entry point for converting a ReSpecTh XML file to a ChemKED YAML file.
     """
     parser = ArgumentParser(
         description='Convert a ReSpecTh XML file to a ChemKED YAML file.'
@@ -574,11 +568,25 @@ def respth2ck(argv=None):
 
     args = parser.parse_args(argv)
 
-    ReSpecTh_to_ChemKED(args.input, args.output, args.file_author, args.file_author_orcid)
+    filename_ck = args.output
+    filename_xml = args.input
+
+    properties = ReSpecTh_to_ChemKED(filename_xml, args.file_author, args.file_author_orcid,
+                                     validate=True)
+
+    # set output filename and path
+    if not filename_ck:
+        filename_ck = os.path.join(os.path.dirname(filename_xml),
+                                   os.path.splitext(os.path.basename(filename_xml))[0] + '.yaml'
+                                   )
+
+    with open(filename_ck, 'w') as outfile:
+        yaml.dump(properties, outfile, default_flow_style=False)
+    print('Converted to ' + filename_ck)
 
 
 def ck2respth(argv=None):
-    """Command-line script for converting a ChemKED YAML file to a ReSpecTh XML file.
+    """Command-line entry point for converting a ChemKED YAML file to a ReSpecTh XML file.
     """
     parser = ArgumentParser(
         description='Convert a ChemKED YAML file to a ReSpecTh XML file.'
@@ -637,7 +645,8 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     if os.path.splitext(args.input)[1] == '.xml' and os.path.splitext(args.output)[1] == '.yaml':
-        ReSpecTh_to_ChemKED(args.input, args.output, args.file_author, args.file_author_orcid)
+        respth2ck(['-i', args.input, '-o', args.output, '-fa', args.file_author,
+                   '-fo', args.file_author_orcid])
 
     elif os.path.splitext(args.input)[1] == '.yaml' and os.path.splitext(args.output)[1] == '.xml':
         c = chemked.ChemKED(yaml_file=args.input)

--- a/pyked/tests/test_chemked.py
+++ b/pyked/tests/test_chemked.py
@@ -244,17 +244,22 @@ class TestConvertToReSpecTh(object):
         """
         file_path = os.path.join(filename_ck)
         filename = pkg_resources.resource_filename(__name__, file_path)
-        c = ChemKED(filename)
+        c_true = ChemKED(filename)
 
         with TemporaryDirectory() as temp_dir:
             newfile = os.path.join(temp_dir, 'test.xml')
-            c.convert_to_ReSpecTh(newfile)
+            c_true.convert_to_ReSpecTh(newfile)
 
-            # convert back to ChemKED, then parse
-            testfile = os.path.join(temp_dir, 'test.yaml')
-            ReSpecTh_to_ChemKED(newfile, testfile)
+            c = ChemKED.from_respecth(newfile)
 
-            c = ChemKED(testfile)
+        assert c.file_authors[0]['name'] == c_true.file_authors[0]['name']
+
+        assert c.reference.detail == 'Converted from ReSpecTh XML file {}'.format(os.path.split(newfile)[1])
+
+        assert c.apparatus.kind == c_true.apparatus.kind
+        assert c.experiment_type == c_true.experiment_type
+        assert c.reference.doi == c_true.reference.doi
+        assert len(c.datapoints) == len(c_true.datapoints)
 
     @pytest.mark.parametrize('experiment_type', [
         'Laminar flame speed measurement', 'Species profile measurement',
@@ -307,7 +312,6 @@ class TestConvertToReSpecTh(object):
                             {'amount': [0.1], 'species-name': 'O2'},
                             {'amount': [0.8], 'species-name': 'Ar'}
                             ]
-
 
     def test_conversion_datapoints_different_composition(self):
         """Test for appropriate handling of datapoints with different composition.

--- a/pyked/tests/test_chemked.py
+++ b/pyked/tests/test_chemked.py
@@ -16,7 +16,7 @@ import pytest
 from ..validation import schema, OurValidator, yaml
 from ..chemked import ChemKED, DataPoint
 from ..utils import Q_
-from ..converters import ReSpecTh_to_ChemKED, get_datapoints, get_common_properties
+from ..converters import get_datapoints, get_common_properties
 
 warnings.simplefilter('always')
 

--- a/pyked/tests/test_converters.py
+++ b/pyked/tests/test_converters.py
@@ -415,7 +415,7 @@ class TestGetExperiment(object):
         root = etree.Element('experiment')
         exp = etree.SubElement(root, 'experimentType')
         exp.text = 'Ignition delay measurement'
-        app = etree.SubElement(root, 'apparatus')
+        etree.SubElement(root, 'apparatus')
 
         with pytest.raises(MissingElementError) as excinfo:
             get_experiment_kind(root)

--- a/pyked/tests/test_converters.py
+++ b/pyked/tests/test_converters.py
@@ -1426,6 +1426,32 @@ class TestConvertReSpecTh(object):
                 ReSpecTh_to_ChemKED(filename)
             assert 'Volume history cannot be defined for shock tube.' in str(excinfo.value)
 
+    def test_author_orcid_no_name(self):
+        """Test that passing an ORCID to the conversion without a name raises an error
+        """
+        file_path = os.path.join('testfile_st.xml')
+        filename = pkg_resources.resource_filename(__name__, file_path)
+        file_author_orcid = '0000-0003-4425-7097'
+        # Skip all the validation because we know the test files are correct and we're not
+        # testing the validation methods here
+        with pytest.raises(KeywordError) as e:
+            ReSpecTh_to_ChemKED(filename, file_author_orcid=file_author_orcid)
+        assert 'If file_author_orcid is specified, file_author must be as well' in str(e.value)
+
+    def test_file_author_only(self):
+        """Test that passing the file author only works properly
+        """
+        file_path = os.path.join('testfile_st.xml')
+        filename = pkg_resources.resource_filename(__name__, file_path)
+        file_author = 'Kyle Niemeyer'
+        # Skip all the validation because we know the test files are correct and we're not
+        # testing the validation methods here
+        properties = ReSpecTh_to_ChemKED(filename, file_author, validate=False)
+        c = ChemKED(dict_input=properties, skip_validation=True)
+
+        assert c.file_authors[1]['name'] == file_author
+        assert c.file_authors[1].get('ORCID', None) is None
+
 
 class TestConverterMain(object):
     """

--- a/pyked/tests/testfile_st.xml
+++ b/pyked/tests/testfile_st.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <experiment>
-    <fileAuthor>Kyle E. Niemeyer</fileAuthor>
+    <fileAuthor>Kyle E Niemeyer</fileAuthor>
     <fileVersion>
         <major>1</major>
         <minor>0</minor>


### PR DESCRIPTION
- [x] Fixes #62.
- [x] Tests added
- [x] Added entry into `CHANGELOG.md`

Changes proposed in this pull request:
 - PEP-8 some of the test code (except for line length). This makes it easier to spot tests that don't test anything
 - Fix the coverage gap opened up in #95
 - Add a method to instantiate a `ChemKED` class directly from a ReSpecTh XML file. The CLI scripts still write the file output
- Improve the tests for the CLI scripts

@pr-omethe-us/chemked
