### PR TITLE
Import the __version__ attribute to the top-level module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - New method to instantiate a `ChemKED` class directly from a ReSpecTh XML file
+- The `__version__` attribute can be imported from the top-level module
 
 ### Changed
 - Crossref lookups via Habanero now comply with the "be-nice" policy

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - pyked
 
   requires:
-    - pytest >=3.0.1
+    - pytest >=3.2.0
     - pytest-cov >=2.3.1
 
   commands:

--- a/pyked/__init__.py
+++ b/pyked/__init__.py
@@ -1,1 +1,2 @@
 from .chemked import ChemKED  # noqa: F401
+from ._version import __version__  # noqa: F401

--- a/pyked/tests/test_chemked.py
+++ b/pyked/tests/test_chemked.py
@@ -300,11 +300,14 @@ class TestConvertToReSpecTh(object):
             tree = etree.parse(newfile)
         root = tree.getroot()
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             common = get_common_properties(root)
-        assert w[0].message.args[0] == 'Missing InChI for species H2'
-        assert w[1].message.args[0] == 'Missing InChI for species O2'
-        assert w[2].message.args[0] == 'Missing InChI for species Ar'
+        m = str(record.pop(UserWarning).message)
+        assert m == 'Missing InChI for species H2'
+        m = str(record.pop(UserWarning).message)
+        assert m == 'Missing InChI for species O2'
+        m = str(record.pop(UserWarning).message)
+        assert m == 'Missing InChI for species Ar'
         assert len(common['composition']['species']) == 3
         for spec in common['composition']['species']:
             assert spec in [{'amount': [0.1], 'species-name': 'H2'},
@@ -648,11 +651,11 @@ class TestDataPoint(object):
 
     def test_absolute_asym_uncertainty(self):
         properties = self.load_properties('testfile_uncertainty.yaml')
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             d = DataPoint(properties[2])
-        assert w[0].message.args[0] == ('Asymmetric uncertainties are not supported. The '
-                                        'maximum of lower-uncertainty and upper-uncertainty '
-                                        'has been used as the symmetric uncertainty.')
+        m = str(record.pop(UserWarning).message)
+        assert m == ('Asymmetric uncertainties are not supported. The maximum of lower-uncertainty '
+                     'and upper-uncertainty has been used as the symmetric uncertainty.')
         assert np.isclose(d.temperature.value, Q_(1164.48, 'K'))
         assert np.isclose(d.temperature.error, Q_(10, 'K'))
         assert np.isclose(d.ignition_delay.value, Q_(471.54, 'us'))
@@ -660,11 +663,11 @@ class TestDataPoint(object):
 
     def test_relative_asym_uncertainty(self):
         properties = self.load_properties('testfile_uncertainty.yaml')
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             d = DataPoint(properties[3])
-        assert w[0].message.args[0] == ('Asymmetric uncertainties are not supported. The '
-                                        'maximum of lower-uncertainty and upper-uncertainty '
-                                        'has been used as the symmetric uncertainty.')
+        m = str(record.pop(UserWarning).message)
+        assert m == ('Asymmetric uncertainties are not supported. The maximum of lower-uncertainty '
+                     'and upper-uncertainty has been used as the symmetric uncertainty.')
         assert np.isclose(d.ignition_delay.value, Q_(471.54, 'us'))
         assert np.isclose(d.ignition_delay.error, Q_(47.154, 'us'))
         assert np.isclose(d.ignition_delay.rel, 0.1)
@@ -674,29 +677,29 @@ class TestDataPoint(object):
 
     def test_absolute_asym_comp_uncertainty(self):
         properties = self.load_properties('testfile_uncertainty.yaml')
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             d = DataPoint(properties[0])
-        assert w[0].message.args[0] == ('Asymmetric uncertainties are not supported. The '
-                                        'maximum of lower-uncertainty and upper-uncertainty '
-                                        'has been used as the symmetric uncertainty.')
+        m = str(record.pop(UserWarning).message)
+        assert m == ('Asymmetric uncertainties are not supported. The maximum of lower-uncertainty '
+                     'and upper-uncertainty has been used as the symmetric uncertainty.')
         assert np.isclose(d.composition[2]['amount'].value, Q_(99.0))
         assert np.isclose(d.composition[2]['amount'].error, Q_(1.0))
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             d = DataPoint(properties[1])
-        assert w[0].message.args[0] == ('Asymmetric uncertainties are not supported. The '
-                                        'maximum of lower-uncertainty and upper-uncertainty '
-                                        'has been used as the symmetric uncertainty.')
+        m = str(record.pop(UserWarning).message)
+        assert m == ('Asymmetric uncertainties are not supported. The maximum of lower-uncertainty '
+                     'and upper-uncertainty has been used as the symmetric uncertainty.')
         assert np.isclose(d.composition[2]['amount'].value, Q_(99.0))
         assert np.isclose(d.composition[2]['amount'].error, Q_(1.0))
 
     def test_relative_asym_comp_uncertainty(self):
         properties = self.load_properties('testfile_uncertainty.yaml')
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             d = DataPoint(properties[1])
-        assert w[0].message.args[0] == ('Asymmetric uncertainties are not supported. The '
-                                        'maximum of lower-uncertainty and upper-uncertainty '
-                                        'has been used as the symmetric uncertainty.')
+        m = str(record.pop(UserWarning).message)
+        assert m == ('Asymmetric uncertainties are not supported. The maximum of lower-uncertainty '
+                     'and upper-uncertainty has been used as the symmetric uncertainty.')
         assert np.isclose(d.composition[0]['amount'].value, Q_(0.444))
         assert np.isclose(d.composition[0]['amount'].error, Q_(0.0444))
         assert np.isclose(d.composition[0]['amount'].rel, 0.1)

--- a/pyked/tests/test_converters.py
+++ b/pyked/tests/test_converters.py
@@ -140,11 +140,11 @@ class TestGetReference(object):
                 'Fig. 12., right, open diamond'
                 )
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             ref = get_reference(root)
-        assert w[1].message.args[0] == ('Using DOI to obtain reference information, '
-                                        'rather than preferredKey.'
-                                        )
+
+        m = str(record.pop(UserWarning).message)
+        assert m == 'Using DOI to obtain reference information, rather than preferredKey.'
 
         assert ref['doi'] == '10.1016/j.ijhydene.2007.04.008'
         assert ref['journal'] == 'International Journal of Hydrogen Energy'
@@ -176,13 +176,13 @@ class TestGetReference(object):
                 'Fig. 12., right, open diamond'
                 )
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             ref = get_reference(root)
-        assert len(w) == 1
-        assert w[0].message.args[0] == ('Missing doi attribute in bibliographyLink. '
-                                        'Setting "detail" key as a fallback; '
-                                        'please update to the appropriate fields.'
-                                        )
+
+        m = str(record.pop(UserWarning).message)
+        assert m == ('Missing doi attribute in bibliographyLink. Setting "detail" key as a '
+                     'fallback; please update to the appropriate fields.')
+
         assert ref['detail'] == ('Chaumeix, N., Pichon, S., Lafosse, F., Paillard, C.-E., '
                                  'International Journal of Hydrogen Energy, 2007, (32) 2216-2226, '
                                  'Fig. 12., right, open diamond.'
@@ -199,13 +199,12 @@ class TestGetReference(object):
                 'Fig. 12., right, open diamond.'
                 )
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             ref = get_reference(root)
-        assert len(w) == 1
-        assert w[0].message.args[0] == ('Missing doi attribute in bibliographyLink. '
-                                        'Setting "detail" key as a fallback; '
-                                        'please update to the appropriate fields.'
-                                        )
+        m = str(record.pop(UserWarning).message)
+        assert m == ('Missing doi attribute in bibliographyLink. Setting "detail" key as a '
+                     'fallback; please update to the appropriate fields.')
+
         assert ref['detail'] == ('Chaumeix, N., Pichon, S., Lafosse, F., Paillard, C.-E., '
                                  'International Journal of Hydrogen Energy, 2007, (32) 2216-2226, '
                                  'Fig. 12., right, open diamond.'
@@ -243,15 +242,13 @@ class TestGetReference(object):
                 'Fig. 12., right, open diamond'
                 )
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             ref = get_reference(root)
 
-        # This test also raises a ResourceWarning from habanero, so there are 2 warnings stored
-        assert len(w) == 2
-        assert w[1].message.args[0] == ('Missing doi attribute in bibliographyLink or lookup failed. '
-                                        'Setting "detail" key as a fallback; please update to '
-                                        'the appropriate fields.'
-                                        )
+        m = str(record.pop(UserWarning).message)
+        assert m == ('Missing doi attribute in bibliographyLink or lookup failed. Setting "detail" '
+                     'key as a fallback; please update to the appropriate fields.')
+
         assert ref['detail'] == (
                 'Chaumeix, N., Pichon, S., Lafosse, F., Paillard, C.-E., '
                 'International Journal of Hydrogen Energy, 2007, (32) 2216-2226, '
@@ -269,15 +266,13 @@ class TestGetReference(object):
                 'Fig. 12., right, open diamond.'
                 )
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             ref = get_reference(root)
 
-        # This test also raises a ResourceWarning from habanero, so there are 2 warnings stored
-        assert len(w) == 2
-        assert w[1].message.args[0] == ('Missing doi attribute in bibliographyLink or lookup failed. '
-                                        'Setting "detail" key as a fallback; please update to '
-                                        'the appropriate fields.'
-                                        )
+        m = str(record.pop(UserWarning).message)
+        assert m == ('Missing doi attribute in bibliographyLink or lookup failed. Setting "detail" '
+                     'key as a fallback; please update to the appropriate fields.')
+
         assert ref['detail'] == (
                 'Chaumeix, N., Pichon, S., Lafosse, F., Paillard, C.-E., '
                 'International Journal of Hydrogen Energy, 2007, (32) 2216-2226, '
@@ -295,13 +290,12 @@ class TestGetReference(object):
                 'Fig. 12., right, open diamond'
                 )
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             ref = get_reference(root)
-        assert len(w) == 1
-        assert w[0].message.args[0] == ('Missing doi attribute in bibliographyLink or lookup failed. '
-                                        'Setting "detail" key as a fallback; please update to '
-                                        'the appropriate fields.'
-                                        )
+        m = str(record.pop(UserWarning).message)
+        assert m == ('Missing doi attribute in bibliographyLink or lookup failed. Setting "detail" '
+                     'key as a fallback; please update to the appropriate fields.')
+
         assert ref['detail'] == ('Chaumeix, N., Pichon, S., Lafosse, F., Paillard, C.-E., '
                                  'International Journal of Hydrogen Energy, 2007, (32) 2216-2226, '
                                  'Fig. 12., right, open diamond.'
@@ -541,9 +535,10 @@ class TestCommonProperties(object):
         amount.set('units', 'mole fraction')
         amount.text = '1.0'
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             get_common_properties(root)
-        assert w[0].message.args[0] == ('Missing InChI for species H2')
+        m = str(record.pop(UserWarning).message)
+        assert m == 'Missing InChI for species H2'
 
     def test_inconsistent_composition_type(self):
         """Check for error when inconsistent composition types.
@@ -601,12 +596,14 @@ class TestCommonProperties(object):
             amount.set('units', spec['units'])
             amount.text = str(spec['amount'])
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             common = get_common_properties(root)
-        assert w[0].message.args[0] == ('Assuming molar ppb in composition and '
-                                        'converting to mole fraction')
-        assert w[1].message.args[0] == ('Assuming molar ppm in composition and '
-                                        'converting to mole fraction')
+
+        m = str(record.pop(UserWarning).message)
+        assert m == 'Assuming molar ppb in composition and converting to mole fraction'
+        m = str(record.pop(UserWarning).message)
+        assert m == 'Assuming molar ppm in composition and converting to mole fraction'
+
         assert common['composition']['kind'] == 'mole fraction'
         assert len(common['composition']['species']) == 3
         assert common['composition']['species'][0]['species-name'] == 'H2'
@@ -637,9 +634,11 @@ class TestCommonProperties(object):
             amount.set('units', spec['units'])
             amount.text = str(spec['amount'])
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             common = get_common_properties(root)
-        assert w[0].message.args[0] == 'Assuming percent in composition means mole percent'
+        m = str(record.pop(UserWarning).message)
+        assert m == 'Assuming percent in composition means mole percent'
+
         assert common['composition']['kind'] == 'mole percent'
         assert len(common['composition']['species']) == 1
         assert common['composition']['species'][0]['species-name'] == 'Ar'
@@ -1201,20 +1200,23 @@ class TestGetDatapoints(object):
         x3 = etree.SubElement(datapoint, 'x3')
         x3.text = str(value)
 
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             datapoints = get_datapoints(root)
-        assert w[0].message.args[0] == 'Missing InChI for species H2'
+        m = str(record.pop(UserWarning).message)
+        assert m == 'Missing InChI for species H2'
+        m = str(record.pop(UserWarning).message)
         if kind == 'percent':
-            assert w[1].message.args[0] == 'Assuming percent in composition means mole percent'
+            assert m == 'Assuming percent in composition means mole percent'
             kind = 'mole percent'
         elif kind == 'ppm':
-            assert w[1].message.args[0] == 'Assuming molar ppm in composition and converting to mole fraction'
+            assert m == 'Assuming molar ppm in composition and converting to mole fraction'
             kind = 'mole fraction'
             value *= 1e-6
         elif kind == 'ppb':
-            assert w[1].message.args[0] == 'Assuming molar ppb in composition and converting to mole fraction'
+            assert m == 'Assuming molar ppb in composition and converting to mole fraction'
             kind = 'mole fraction'
             value *= 1e-9
+
         assert len(datapoints) == 1
         datapoint = datapoints[0]
         assert datapoint['temperature'] == [str(1000.0) + ' K']

--- a/pyked/tests/test_validation.py
+++ b/pyked/tests/test_validation.py
@@ -149,17 +149,20 @@ class TestValidator(object):
                    {'name': 'Kyle Brady', 'ORCID': '0000-0002-4664-3680'},
                    {'name': 'Chih-Jen Sung'}, {'name': 'Xin Hui'}
                    ]
-        with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning) as record:
             v.validate(
                 {'reference': {'authors': authors, 'doi': '10.1016/j.combustflame.2015.06.017'}},
                 update=True,
             )
+        m = str(record.pop(UserWarning).message)
+        assert m == 'ORCID 0000-0003-4425-7097 missing for Kyle E Niemeyer'
 
     @internet_missing
     def test_missing_author(self):
         """Test for proper error for missing author.
         """
-        authors = [{'name': 'Kyle E Niemeyer'}, {'name': 'Kyle Brady'},
+        authors = [{'name': 'Kyle E Niemeyer', 'ORCID': '0000-0003-4425-7097'},
+                   {'name': 'Kyle Brady', 'ORCID': '0000-0002-4664-3680'},
                    {'name': 'Chih-Jen Sung'}
                    ]
         v.validate(
@@ -201,7 +204,8 @@ class TestValidator(object):
         """Ensure appropriate error for extra authors given.
         """
         # update=True means to ignore required keys that are left out for testing
-        authors = [{'name': 'Kyle E Niemeyer'}, {'name': 'Kyle Brady'},
+        authors = [{'name': 'Kyle E Niemeyer', 'ORCID': '0000-0003-4425-7097'},
+                   {'name': 'Kyle Brady', 'ORCID': '0000-0002-4664-3680'},
                    {'name': 'Chih-Jen Sung'}, {'name': 'Xin Hui'},
                    {'name': 'Bryan W Weber'}
                    ]

--- a/pyked/tests/test_validation.py
+++ b/pyked/tests/test_validation.py
@@ -98,18 +98,20 @@ class TestValidator(object):
     def test_doi_missing_internet(self, disable_socket):
         """Ensure that DOI validation fails gracefully with no Internet.
         """
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             v.validate({'reference': {'doi': '10.1016/j.combustflame.2009.12.022'}}, update=True)
 
-        assert w[0].message.args[0] == 'network not available, DOI not validated.'
+        m = str(record.pop(UserWarning).message)
+        assert m == 'network not available, DOI not validated.'
 
     def test_orcid_missing_internet(self, disable_socket):
         """Ensure that ORCID validation fails gracefully with no Internet.
         """
-        with pytest.warns(UserWarning) as w:
+        with pytest.warns(UserWarning) as record:
             v.validate({'file-authors': [{'ORCID': '0000-0003-4425-7097'}]}, update=True)
 
-        assert w[0].message.args[0] == 'network not available, ORCID not validated.'
+        m = str(record.pop(UserWarning).message)
+        assert m == 'network not available, ORCID not validated.'
 
     @internet_missing
     def test_invalid_DOI(self):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
 ]
 
 tests_require = [
-    'pytest>=3.0.1',
+    'pytest>=3.2.0',
     'pytest-cov',
 ]
 

--- a/test-environment.yaml
+++ b/test-environment.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - numpy>=1.11.0
   - pyyaml>=3.12
-  - pytest>=3.0.0
+  - pytest>=3.2.0
   - pytest-cov>=2.3.1
   - python=${PYTHON}
   - cerberus>=1.0.0


### PR DESCRIPTION
- [x] Fixes #98
- [x] Added entry into `CHANGELOG.md`

Changes proposed in this pull request:
- Add the ability to import the `__version__` attribute from the `_version` module at the top-level of the package

```python
from pyked import __version__
print(__version__)
```


@pr-omethe-us/chemked
