### PR TITLE
Add "d/dt max extrapolated" ignition type to docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
       elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-        rvm get stable;
       fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"

--- a/docs/schema-docs.rst
+++ b/docs/schema-docs.rst
@@ -218,6 +218,7 @@ for the :ref:`datapoints <meta-datapoints>` schema.
             * ``max``: maximum of the ``target``
             * ``1/2 max``: half-maximum of the ``target``
             * ``min``: minimum of the ``target``
+            * ``d/dt max extrapolated``: maximum slope of the target extrapolated to the baseline
 
 .. _ignition-ignition-delay:
 


### PR DESCRIPTION
- [x] Documentation updated

Changes proposed in this pull request:
- Adds `d/dt max extrapolated` to list of `ignition-type` `type` in schema documentation

@pr-omethe-us/chemked