### PR TITLE
Add alphas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New `time-histories` field to replace the `volume-history`. This field allows specification of several other relevant parameters besides volume.
 - Added `rcm-data` field and moved `compressed-temperature`, `compressed-pressure`, and `compression-time` to this field
 - Added `stroke`, `clearance`, and `compression-ratio` to the `rcm-data` field
+- Allow alpha versions to be specified during testing
 
 ### Changed
 - Crossref lookups via Habanero now comply with the "be-nice" policy

--- a/build-environment.yaml
+++ b/build-environment.yaml
@@ -10,7 +10,6 @@ dependencies:
   - pandas
   - uncertainties
   - habanero>=0.6.0
-  - orcid
   - sphinx
   - nbsphinx
   - ipython

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - pint >=0.7.2,<0.9
     - numpy >=1.11.0,<2.0
     - habanero >=0.6.0
-    - orcid >=0.7.0,<1.0
     - uncertainties >=3.0.1
     - pandas
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3.6', None),
     'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'requests': ('http://docs.python-requests.org/en/master/', None),
 }
 
 # Make the module index more useful by sorting on the module name

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ Code API
    chemked
    converters
    validation
+   orcid
 
 
 

--- a/docs/orcid.rst
+++ b/docs/orcid.rst
@@ -1,0 +1,5 @@
+=====
+ORCID
+=====
+
+.. automodule:: pyked.orcid

--- a/pyked/_version.py
+++ b/pyked/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (0, 3, 0)
+__version_info__ = (0, 4, 0, 'a1')
 __version__ = '.'.join(map(str, __version_info__[:3]))
 if len(__version_info__) == 4:
     __version__ += __version_info__[-1]

--- a/pyked/orcid.py
+++ b/pyked/orcid.py
@@ -1,0 +1,29 @@
+"""
+Module for ORCID interaction
+"""
+import requests
+headers = {'Accept': 'application/json'}
+
+
+def search_orcid(orcid):
+    """
+    Search the ORCID public API
+
+    Specfically, return a dictionary with the personal details
+    (name, etc.) of the person associated with the given ORCID
+
+    Args:
+        orcid (`str`): The ORCID to be searched
+
+    Returns:
+        `dict`: Dictionary with the JSON response from the API
+
+    Raises:
+        `~requests.HTTPError`: If the given ORCID cannot be found, an `~requests.HTTPError`
+            is raised with status code 404
+    """
+    url = 'https://pub.orcid.org/v2.1/{orcid}/person'.format(orcid=orcid)
+    r = requests.get(url, headers=headers)
+    if r.status_code != 200:
+        r.raise_for_status()
+    return r.json()

--- a/pyked/tests/test_chemked.py
+++ b/pyked/tests/test_chemked.py
@@ -17,6 +17,9 @@ import pytest
 from ..validation import schema, OurValidator, yaml, Q_
 from ..chemked import ChemKED, DataPoint
 from ..converters import get_datapoints, get_common_properties
+from .._version import __version__
+
+schema['chemked-version']['allowed'].append(__version__)
 
 warnings.simplefilter('always')
 

--- a/pyked/tests/test_validation.py
+++ b/pyked/tests/test_validation.py
@@ -12,6 +12,7 @@ import pytest
 import yaml
 
 from ..validation import schema, OurValidator, compare_name, property_units
+from .._version import __version__
 
 
 def no_internet(host='8.8.8.8', port=53, timeout=1):
@@ -28,6 +29,8 @@ def no_internet(host='8.8.8.8', port=53, timeout=1):
 
 
 internet_missing = pytest.mark.skipif(no_internet(), reason='Internet not available')
+
+schema['chemked-version']['allowed'].append(__version__)
 
 v = OurValidator(schema)
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ install_requires = [
     'pint>=0.7.2',
     'numpy>=1.11.0',
     'habanero>=0.6.0',
-    'orcid>=0.7.0,<1.0',
     'uncertainties>=3.0.1',
 ]
 


### PR DESCRIPTION
- [x] Fixes #108
- [x] Added entry into `CHANGELOG.md`
- [x] Documentation updated

Changes proposed in this pull request:
- Allow us to set alpha versions in `_version` and still pass the tests. Essentially, needed to modify the `schema` dictionary only during testing to append the current version

@pr-omethe-us/chemked
