### PR TITLE
adds repo protection for docs and publish workflows

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.repository == 'pr-omethe-us/PyKED'
     permissions:
       contents: write
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'pr-omethe-us/PyKED'
 
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +34,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: pypi
+    if: github.repository == 'pr-omethe-us/PyKED'
     permissions:
       id-token: write
 


### PR DESCRIPTION
Previously, docs and publish workflows would run on forks.